### PR TITLE
Adding yarn.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+yarn.lock


### PR DESCRIPTION
Sometimes while performing `bundle install` or `yarn install` this file is changed, which should be ignored by git
On the first time you wish to run the server you should run these commands, before trying to run the server.